### PR TITLE
Fix perl-reversion to not match with v-prefix in "pre"

### DIFF
--- a/examples/perl-reversion
+++ b/examples/perl-reversion
@@ -212,7 +212,7 @@ sub version_re_perl {
   my $ver_re = shift;
 
   return
-   qr{ ^ ( .*?  [\$\*] (?: \w+ (?: :: | ' ) )* VERSION \s* = \D* ) 
+   qr{ ^ ( .*?  [\$\*] (?: \w+ (?: :: | ' ) )* VERSION \s* = \D*? )
                  $ver_re 
                  ( .* ) $ }x;
 }

--- a/t/40.perl-reversion.t
+++ b/t/40.perl-reversion.t
@@ -20,7 +20,7 @@ my $RUN = "$^X $libs examples/perl-reversion";
 if ( system( "$RUN -quiet" ) ) {
   plan skip_all => 'cannot run perl-reversion, skipping its tests';
 }
-plan tests => 20;
+plan tests => 22;
 
 my $dir = File::Temp::tempdir( CLEANUP => 1 );
 
@@ -128,6 +128,20 @@ our $VERSION = '1.2.3';
 1;
 END
   sub { runtests( pm => "1.2.3" ) },
+);
+
+with_file(
+  "Foo.pm", <<'END',
+package Foo;
+our $VERSION = version->declare('v1.2.3');
+1;
+END
+  sub {
+    is_deeply( find( $dir ), { found => 'v1.2.3' }, "found in pm" );
+    _run( $dir, '-set', '1.2' );
+    _run( $dir, '-bump' );
+    is_deeply( find( $dir ), { found => 'v1.3' }, "bump subversion with v prefix" );
+  },
 );
 
 with_file(


### PR DESCRIPTION
If you have a version line like:

```
$VERSION = version->declare('v0.1.2')
```

perl-reversion seems to swallow the 'v' part in its `version_re_perl`. This commit changes the match with '?' in its regexp so that Perl::Version::REGEX can correctly capture the 'v' part.

Realistically, perl-reversion works fine without this patch, since handling the 'v' part as a pre-text causes no troubles, but this patch feels more correct.
